### PR TITLE
fix: glob pattern 匹配模块文件失效

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -10,13 +10,13 @@ function requireUncached (module) {
 
 const DIR = 'modules'
 
-const getModuleRouter = (routerFileName, modulePath) => fg.sync(`*/${routerFileName}.{js|mjs|ts}`, {
+const getModuleRouter = (routerFileName, modulePath) => fg.sync(`*/${routerFileName}.{js,mjs,ts}`, {
   deep: 2,
   onlyFiles: true,
   cwd: modulePath
 })
 
-const getModuleStore = (storeDirName, modulePath) => fg.sync(`*/${storeDirName}/**/*.{js|mjs|ts}`, {
+const getModuleStore = (storeDirName, modulePath) => fg.sync(`*/${storeDirName}/**/*.{js,mjs,ts}`, {
   onlyFiles: true,
   cwd: modulePath
 })


### PR DESCRIPTION
## Why
a wrong glob pattern make features not work
